### PR TITLE
修复京东shareUrl不在最后一个数组时的报错

### DIFF
--- a/js/jd_price.js
+++ b/js/jd_price.js
@@ -27,7 +27,13 @@ if (url.indexOf(path3) != -1) {
 if (url.indexOf(path2) != -1) {
     let obj = JSON.parse(body);
     const floors = obj.floors;
-    const commodity_info = floors[floors.length - 1];
+    let commodity_info = floors[floors.length - 1];
+    for (let index = 0; index < floors.length; index++) {
+        let tmp = floors[index];
+        if (tmp.bId == 'eCustom_flo_201') {
+            commodity_info = tmp; 
+        }
+    }
     const shareUrl = commodity_info.data.property.shareUrl;
     request_history_price(shareUrl, function (data) {
         if (data) {


### PR DESCRIPTION
shareUrl 有时候不在最后一个数组，此时打开商品页面会因js报错而页面空白。
可以通过数据 bId 字段来确定 shareUrl 所在对象